### PR TITLE
중고 서적 URL에서 특수문자 제거

### DIFF
--- a/build/resources/main/templates/books/book-search-save.html
+++ b/build/resources/main/templates/books/book-search-save.html
@@ -63,30 +63,17 @@
             </table>
 
             <nav th:if="${searchMeta != null}" aria-label="Page navigation">
-                <ul class="pagination justify-content-center"
-                    th:with="startNumber=${T(Math).floor((searchPage-1)/10)}*10+1,
-                             endNumber=(${T(Math).floor(searchMeta.pageableCount/10)} > ${startNumber}+9) ? ${startNumber} + 9 : ${T(Math).floor(searchMeta.pageableCount/10)}">
-
-                    <li class="page-item">
-                        <a class="page-link" th:href="@{/api/v1/books/new/{searchKeyword}/1 (searchKeyword=${searchKeyword})}">&laquo;</a>
-                    </li>
-
+                <ul class="pagination justify-content-center">
                     <li th:style="(${searchPage} == 1) ? 'display:none'">
                         <a class="page-link" th:href="@{/api/v1/books/new/{searchKeyword}/{page} (searchKeyword=${searchKeyword},page=${searchPage-1})}">&lsaquo;</a>
                     </li>
 
-                    <li th:each="page : ${#numbers.sequence(startNumber, endNumber)}"
-                        class="page-item"
-                        th:th:classappend="(${page} == ${searchPage}) ? active">
-                        <a class="page-link" th:href="@{/api/v1/books/new/{searchKeyword}/{page} (searchKeyword=${searchKeyword},page=${page})}" th:text="${page}"></a>
+                    <li class="page-item active">
+                        <a class="page-link" th:href="@{/api/v1/books/new/{searchKeyword}/{page} (searchKeyword=${searchKeyword},page=${searchPage})}" th:text="${searchPage}"></a>
                     </li>
 
                     <li th:style="${isEnd} ? 'display:none'">
                         <a class="page-link" th:href="@{/api/v1/books/new/{searchKeyword}/{page} (searchKeyword=${searchKeyword},page=${searchPage+1})}">&rsaquo;</a>
-                    </li>
-
-                    <li class="page-item">
-                        <a class="page-link" th:href="@{/api/v1/books/new/{searchKeyword}/{page} (searchKeyword=${searchKeyword},page=${searchMeta.pageableCount/10})}">&raquo;</a>
                     </li>
                 </ul>
             </nav>

--- a/build/resources/main/templates/layouts/body-header.html
+++ b/build/resources/main/templates/layouts/body-header.html
@@ -5,7 +5,7 @@
     <a class="navbar-brand" href="/api/v1/books/plannedList">
         <img th:src="${userPicture}" width="30" height="30" class="profile-image d-inline-block align-content-center" alt=""
              style="border-radius: 50%; margin-right: 10px">
-        <span th:text="${userName} + ' 님의 서재'" style="font-size: small"></span>
+        <span th:text="${userName} + '님의 서재'" style="font-size: small"></span>
     </a>
 
     <span>

--- a/build/tmp/bootJar/MANIFEST.MF
+++ b/build/tmp/bootJar/MANIFEST.MF
@@ -1,2 +1,7 @@
 Manifest-Version: 1.0
+Start-Class: com.ggproject.myBookshelf.MyBookshelfApplication
+Spring-Boot-Classes: BOOT-INF/classes/
+Spring-Boot-Lib: BOOT-INF/lib/
+Spring-Boot-Version: 2.2.5.RELEASE
+Main-Class: org.springframework.boot.loader.JarLauncher
 

--- a/src/main/java/com/ggproject/myBookshelf/dto/UsedBookSearchStoreInfoDto.java
+++ b/src/main/java/com/ggproject/myBookshelf/dto/UsedBookSearchStoreInfoDto.java
@@ -18,4 +18,8 @@ public class UsedBookSearchStoreInfoDto {
 
     @JsonProperty("link")
     private String link;
+
+    public void setLink(String link) {
+        this.link = link.replace("&amp;", "&");
+    }
 }

--- a/src/test/java/com/ggproject/myBookshelf/dto/UsedBookSearchStoreInfoDtoTest.java
+++ b/src/test/java/com/ggproject/myBookshelf/dto/UsedBookSearchStoreInfoDtoTest.java
@@ -1,0 +1,23 @@
+package com.ggproject.myBookshelf.dto;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UsedBookSearchStoreInfoDtoTest {
+
+    @Test
+    public void URL_특수문자_제거() {
+
+        // given
+        String url = "http://www.aladin.co.kr/usedstore/wproduct.aspx?ItemId=19505671&amp;OffCode=Daegu&amp;partner=openAPI";
+        UsedBookSearchStoreInfoDto storeInfoDto = new UsedBookSearchStoreInfoDto();
+
+        // when
+        storeInfoDto.setLink(url);
+
+        // then
+        String expectedUrl = "http://www.aladin.co.kr/usedstore/wproduct.aspx?ItemId=19505671&OffCode=Daegu&partner=openAPI";
+        assertThat(storeInfoDto.getLink()).isEqualTo(expectedUrl);
+    }
+}


### PR DESCRIPTION
- 알라딘 중고 서적 링크를 제공할 때, URL에서 특수문자 제거